### PR TITLE
Add a return value to overwritten res.json() for chaining.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function(option) {
         if (!res.get('Content-Type')) {
           res.set('Content-Type', 'application/json');
         }
-        res.send(JSON.stringify(body, null, spaces));
+        return res.send(JSON.stringify(body, null, spaces));
       }
     }
     next();


### PR DESCRIPTION
This commit adds the return value, i.e. the `res`-object, to the overwritten `res.json()` method to allow chaining like `res.json({ hello: 'world', body: 'This is pretty printed json' }).end();`